### PR TITLE
Fixes IPC conflict with Bull job messages

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,11 +13,16 @@ const myPmId = Number(process.env.pm_id);
 let myBus: any;
 const myBusListeners: Record<string, (instanceId: number, message: any) => void> = {};
 
-process.on('message', async ({ topic, data: { targetInstanceId, requestId, data } }: RequestPacket): Promise<void> => {
+process.on('message', async (requestPacket: RequestPacket): Promise<void> => {
+  if (!requestPacket.topic) {
+    return;
+  }
+
+  const { topic, data: { targetInstanceId, requestId, data } } = requestPacket;
   if (typeof handlers[topic] === 'function' && process.send) {
     const response: ResponsePacket<any> = {
       type: `process:${targetInstanceId}`,
-      data: { instanceId: myPmId, requestId, message: await handlers[topic](data) },
+      data: {instanceId: myPmId, requestId, message: await handlers[topic](data)},
     };
 
     process.send(response);


### PR DESCRIPTION
#### Context:
- a bunch of node processes running under `pm2` with `cluster` mode on
- all processes use `pm2-messages` to send metrics to an aggregator/exporter (uses the IPC channel)
- some of these processes are "Sandboxed workers" consuming jobs from a Bull queue (they also use the same IPC channel)

#### Problem:
When a job is pushed to the queue, those worker processes would crash with error:
```
TypeError: Cannot read property 'targetInstanceId' of undefined
    at process.<anonymous> (/node_modules/pm2-messages/lib/index.js:21:41)
    at process.emit (events.js:326:22)
    at emit (internal/child_process.js:902:12)
    at processTicksAndRejections (internal/process/task_queues.js:81:21)
```

This is because `pm2-messages` expects a single type of message coming through the IPC channel, a `get_prom_register` message. 
However, `bull` too will send messages (job-related), with a different structure, and `pm2-messages` doesn't know how to handle this.

#### Solution:
`pm2-messages` should ignore all messages that are not intended for it (i.e. do not have property `topic`).
